### PR TITLE
Add solution, project, and program for local running.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Watch: dotnet watch build",
+        "type": "shell",
+        "command": "dotnet watch build",
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        },
+        "problemMatcher": "$msCompile",
+        "runOptions": {
+          "runOn": "folderOpen"
+        },
+        "isBackground": true
+      }
+    ]
+  }

--- a/Build.csproj
+++ b/Build.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Metalsharp" Version="0.9.0-rc.5" />
+    <PackageReference Include="Metalsharp.LiquidTemplates" Version="0.9.0-rc-3" />
+    <PackageReference Include="Metalsharp.SimpleBlog" Version="0.9.0-rc.2" />
+    <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
+  </ItemGroup>
+
+  <Target Name="GenerateCsxFile" AfterTargets="Build">
+    <ItemGroup>
+      <SourceFiles Include="Program.cs" />
+    </ItemGroup>
+    
+    <Copy SourceFiles="@(SourceFiles)" DestinationFolder="$(OutputPath)" />
+    
+    <WriteLinesToFile File="build.csx" Overwrite="true"
+      Lines="
+#! &quot;net8.0&quot;
+#r &quot;nuget: Metalsharp, 0.9.0-rc.5&quot;
+#r &quot;nuget: Metalsharp.LiquidTemplates, 0.9.0-rc-3&quot;
+#r &quot;nuget: Metalsharp.SimpleBlog, 0.9.0-rc.2&quot;
+#r &quot;nuget: System.ServiceModel.Syndication, 8.0.0&quot;
+" 
+    />
+
+    <Exec Command="type @(SourceFiles) >> build.csx" />
+  </Target>
+</Project>

--- a/Build.sln
+++ b/Build.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Build", "Build.csproj", "{A6163207-B097-456C-8721-DEAB980213B9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A6163207-B097-456C-8721-DEAB980213B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6163207-B097-456C-8721-DEAB980213B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6163207-B097-456C-8721-DEAB980213B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6163207-B097-456C-8721-DEAB980213B9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -1,0 +1,3 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "SYSLIB1045:Convert to 'GeneratedRegexAttribute'.", Justification = "Annoying")]

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,3 @@
-#! "net8.0"
-#r "nuget: Metalsharp, 0.9.0-rc.5"
-#r "nuget: Metalsharp.LiquidTemplates, 0.9.0-rc-3"
-#r "nuget: Metalsharp.SimpleBlog, 0.9.0-rc.2"
-#r "nuget: System.ServiceModel.Syndication, 8.0.0"
 using Metalsharp;
 using Metalsharp.LiquidTemplates;
 using Metalsharp.SimpleBlog;

--- a/build-legacy.csx
+++ b/build-legacy.csx
@@ -1,8 +1,9 @@
-#! "net8.0"
+﻿#! "net8.0"
 #r "nuget: Metalsharp, 0.9.0-rc.5"
 #r "nuget: Metalsharp.LiquidTemplates, 0.9.0-rc-3"
 #r "nuget: Metalsharp.SimpleBlog, 0.9.0-rc.2"
 #r "nuget: System.ServiceModel.Syndication, 8.0.0"
+
 using Metalsharp;
 using Metalsharp.LiquidTemplates;
 using Metalsharp.SimpleBlog;
@@ -13,8 +14,6 @@ using System.IO;
 using System.Xml;
 using System;
 using System.Text.Json;
-using System.Collections.Generic;
-using System.Linq;
 
 IEnumerable<SeriesInfo> seriesInfo = [];
 


### PR DESCRIPTION
It's easier to test locally using a sln, proj, and program.cs.

This includes a build script to generate build.csx from the program file, and executes watch when opening in VSCode to ensure the build.csx is always generated.